### PR TITLE
Fix: upgrade to the latest @lwce/router

### DIFF
--- a/packages/storefront-lwc/package.json
+++ b/packages/storefront-lwc/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@lwc/synthetic-shadow": "1.7.1",
     "@lwce/apollo-client": "0.2.0",
-    "@lwce/router": "^0.4.1",
+    "@lwce/router": "^0.4.4",
     "@salesforce-ux/design-system": "^2.9.4",
     "@sfcc-bff/productapi": "1.0.0-alpha.2",
     "@sfcc-core/apiconfig": "1.0.0-alpha.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2505,10 +2505,10 @@
   dependencies:
     apollo-client "^2.6.4"
 
-"@lwce/router@^0.4.1":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@lwce/router/-/router-0.4.2.tgz#1a68497f0c986e822b1b76fa21ecc8a55d201729"
-  integrity sha512-k2PCNZujbwvdELtsoa0E1xjx8gADY8LI+j2wvV+rhFcygP+lDehpzLpRf1X3zuF2Y8/i5ibwJCMDN+g4upHYSQ==
+"@lwce/router@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@lwce/router/-/router-0.4.4.tgz#7a34a26302f299ee05698c0526f1ac9269b2c503"
+  integrity sha512-Dws2mIMapFHJVHitlXrPpahc7ysJJ+4j6GeGvVo38NmCgM9RpkBX8ZrWKvE30dw5BYjrP5O76999gnswPS2Jbg==
   dependencies:
     history "^4.10.1"
     path-to-regexp "^6.1.0"


### PR DESCRIPTION
This fixes some critical bugs where the routeParams and history wire adapter weren't properly getting initialized on page load. This means that currently, if you try to search a product in the app using the top navigation, there is a critical error. Also, if you navigate to a product and refresh the page, you will also see an error.

The fix lies within @lwce/router. See the change here for more information: https://github.com/LWC-Essentials/router/commit/c9b447ced812d658f27dd1ef895dcdccea0b5a11#diff-6a1ee8738e4ad22fe971367a75800387R34

Essentially I should have been using `connectedCallback` instead of `renderCallback` because the latter doesn't run until after children are rendered. I need it to run before children are rendered, because the children of the component need access to the wire adapter context.

## All Pull Requests:
* [x] Have you considered Security (e.g. XSS)?
* [x] Have you considered desktop, mobile and tablet form-factors?
* [x] Have you considered Accessibility best practices?

### Code
* [x] Are the commits squashed into one commit?
* [x] Is the branch name and commit message following team convention?
* [x] Is the code linted?
* [x] Are all open issues, questions and concerns by Reviewers answered, resolved and reviewed?

### Quality Assurance
* [x] If applicable, are Unit Tests written and all tests are passing?
* [x] If applicable, are Integration Tests written and all tests are passing?
* [x ] If applicable, are UI Automation Tests written and all tests are passing?

### Documentation
* [x] Are there meaningful code comments included?
* [x] If applicable, are test cases written?
* [x] If applicable, is Change Log updated?
* [x] If applicable, are UI Texts reviewed by Documentation?

### Security
* [ ] If applicable, has Security reviewed this code?
* [ ] If applicable, is a 3PP request submitted?
